### PR TITLE
Build google/double-conversion as a stic lib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ RUN git clone https://github.com/google/double-conversion.git /usr/src/double-co
     make install && \
     make clean && \
     cmake -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_SHARED_LIBS=ON. && \
+      -DBUILD_SHARED_LIBS=ON . && \
     make -j2 && \
     make install && \
     make clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,8 +116,12 @@ RUN git clone https://github.com/google/double-conversion.git /usr/src/double-co
     cd /usr/src/double-conversion && \
     git checkout ${DOUBLE_SHA} && \
     ldconfig && \
-    cmake -DCMAKE_BUILD_TYPE=Release \ 
-      -DBUILD_SHARED_LIBS=ON . && \
+    cmake -DCMAKE_BUILD_TYPE=Release . && \
+    make -j2 && \
+    make install && \
+    make clean && \
+    cmake -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=ON. && \
     make -j2 && \
     make install && \
     make clean && \


### PR DESCRIPTION
Ooops missed this one.
Tested and now I'm able to copy a binary built with folly and wangle on a box with none of the deps installed.